### PR TITLE
feat(windows): Add CCAP_WIN_NO_DEVICE_VERIFY option to skip device verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 option(CCAP_NO_LOG "Disable logging" OFF)
 option(CCAP_BUILD_SHARED "Build ccap as shared library" OFF)
+option(CCAP_WIN_NO_DEVICE_VERIFY "Skip device verification on Windows (for buggy camera drivers)" OFF)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CCAP_IS_ROOT_PROJECT ON)
@@ -169,6 +170,11 @@ target_compile_definitions(ccap PUBLIC
 if(CCAP_NO_LOG)
     target_compile_definitions(ccap PUBLIC CCAP_NO_LOG=1)
     message(STATUS "ccap: Disable logging")
+endif()
+
+if(CCAP_WIN_NO_DEVICE_VERIFY)
+    target_compile_definitions(ccap PRIVATE CCAP_WIN_NO_DEVICE_VERIFY=1)
+    message(STATUS "ccap: Skip device verification on Windows (for buggy camera drivers)")
 endif()
 
 # Configure shared library export definitions

--- a/docs/CMAKE_OPTIONS.md
+++ b/docs/CMAKE_OPTIONS.md
@@ -1,0 +1,138 @@
+# CMake Build Options
+
+This document describes all available CMake options for building the ccap (Camera Capture) library.
+
+## General Options
+
+### CCAP_NO_LOG
+- **Description**: Disable logging throughout the library
+- **Type**: Boolean (ON/OFF)
+- **Default**: OFF
+- **Example**: `-DCCAP_NO_LOG=ON`
+- **Notes**: When enabled, all logging macros (CCAP_LOG_*) are disabled, reducing binary size and improving performance
+
+### CCAP_BUILD_SHARED
+- **Description**: Build ccap as a shared library instead of static
+- **Type**: Boolean (ON/OFF)
+- **Default**: OFF
+- **Example**: `-DCCAP_BUILD_SHARED=ON`
+- **Notes**: When enabled, the library is built as a shared library (.dll on Windows, .so on Linux, .dylib on macOS)
+
+### CCAP_INSTALL
+- **Description**: Generate installation target for the library
+- **Type**: Boolean (ON/OFF)
+- **Default**: ON (if ccap is the root project), OFF (if used as a subdirectory)
+- **Example**: `-DCCAP_INSTALL=ON`
+- **Notes**: When enabled, allows installation of headers, library, and CMake config files via `cmake --install`
+
+## Windows-Specific Options
+
+### CCAP_WIN_NO_DEVICE_VERIFY
+- **Description**: Skip device verification during enumeration on Windows
+- **Type**: Boolean (ON/OFF)
+- **Default**: OFF
+- **Example**: `-DCCAP_WIN_NO_DEVICE_VERIFY=ON`
+- **Purpose**: Prevents crashes caused by buggy camera drivers (e.g., Oculus Quest 3 VR headset when unplugged) that fail during `IMoniker::BindToObject()` or `filter->Release()` calls
+- **Notes**: 
+  - Only affects Windows platform
+  - When enabled, device names are added without instantiating filters
+  - Device properties are still verified via `enumerateDevices()`
+  - Safe to enable for compatibility with problematic drivers
+  - Related to issue #26
+
+## Build Configuration Options
+
+### CCAP_BUILD_EXAMPLES
+- **Description**: Build example programs
+- **Type**: Boolean (ON/OFF)
+- **Default**: ON (if ccap is the root project), OFF (if used as a subdirectory)
+- **Example**: `-DCCAP_BUILD_EXAMPLES=ON`
+- **Notes**: Includes desktop examples with GLFW for visualization
+
+### CCAP_BUILD_TESTS
+- **Description**: Build unit tests
+- **Type**: Boolean (ON/OFF)
+- **Default**: OFF
+- **Example**: `-DCCAP_BUILD_TESTS=ON`
+- **Notes**: Requires GoogleTest framework; enables `enable_testing()` and CTest integration
+
+## Architecture Options
+
+### CCAP_FORCE_ARM64
+- **Description**: Force ARM64 architecture compilation
+- **Type**: Boolean (ON/OFF)
+- **Default**: OFF
+- **Example**: `-DCCAP_FORCE_ARM64=ON`
+- **Platforms**: macOS, Windows
+- **Notes**: 
+  - On macOS: Sets `CMAKE_OSX_ARCHITECTURES` to "arm64"
+  - On Windows: Sets `CMAKE_GENERATOR_PLATFORM` to "ARM64"
+  - Enables NEON support on ARM64
+  - Useful for cross-compilation or universal binary generation
+
+## Usage Examples
+
+### Build with default settings (static library)
+```bash
+cmake -B build
+cmake --build build
+```
+
+### Build as shared library
+```bash
+cmake -B build -DCCAP_BUILD_SHARED=ON
+cmake --build build
+```
+
+### Build with examples and tests
+```bash
+cmake -B build -DCCAP_BUILD_EXAMPLES=ON -DCCAP_BUILD_TESTS=ON
+cmake --build build
+```
+
+### Build with Windows device verification disabled
+```bash
+cmake -B build -DCCAP_WIN_NO_DEVICE_VERIFY=ON
+cmake --build build
+```
+
+### Build for ARM64 with all features disabled
+```bash
+cmake -B build -DCCAP_FORCE_ARM64=ON -DCCAP_NO_LOG=ON
+cmake --build build
+```
+
+### Install the library
+```bash
+cmake -B build -DCCAP_INSTALL=ON
+cmake --build build
+cmake --install build --prefix /usr/local
+```
+
+## Related CMake Variables
+
+The following CMake variables can also be used to customize the build:
+
+- `CMAKE_BUILD_TYPE`: Set to Debug, Release, RelWithDebInfo, or MinSizeRel
+- `CMAKE_OSX_DEPLOYMENT_TARGET`: Minimum macOS version (default: 10.13)
+- `CMAKE_CXX_STANDARD`: C++ standard version (fixed to 17 by ccap)
+
+## Platform-Specific Notes
+
+### Windows
+- When `CCAP_WIN_NO_DEVICE_VERIFY` is enabled, the library skips filter instantiation during device enumeration
+- MSVC is the primary compiler; MinGW and Clang are also supported
+
+### macOS
+- Requires framework linking for AVFoundation, CoreVideo, CoreMedia, and Accelerate
+- ARM64 support is fully integrated
+
+### Linux
+- Requires pthread library for thread support
+- Standard V4L2 device access
+
+## Related Files
+
+- `CMakeLists.txt` - Main build configuration
+- `src/ccap_imp_windows.cpp` - Windows implementation (affected by CCAP_WIN_NO_DEVICE_VERIFY)
+- `include/ccap_config.h` - Configuration macros


### PR DESCRIPTION
## Summary

This PR addresses crashes during device enumeration on Windows when using buggy camera drivers (e.g., Oculus Quest 3 VR headset when unplugged). The solution provides an optional CMake configuration to skip device filter instantiation during enumeration, preventing calls to problematic `IMoniker::BindToObject()` or `filter->Release()` methods.

## Problem

Some camera devices with faulty DirectShow drivers cause application crashes when:
- Enumerating available camera devices via `findDeviceNames()`
- Attempting to instantiate filters during the enumeration process
- Releasing filter objects

The crash occurs when buggy driver code is executed in external DLLs, particularly during `BindToObject()` or `Release()` calls, which cannot be reliably caught with SEH (Structured Exception Handling).

Related to: #26

## Solution

Introduces a new CMake option `CCAP_WIN_NO_DEVICE_VERIFY` that allows skipping filter instantiation during device enumeration. Since device properties are already verified via `enumerateDevices()` (which calls `IMoniker::BindToStorage()` for friendly name retrieval), skipping the filter instantiation step is safe and functional.

### Key Changes

1. **CMakeLists.txt**
   - Added `CCAP_WIN_NO_DEVICE_VERIFY` CMake option (default: OFF)
   - Configured as PRIVATE compile definition to avoid leaking to library consumers

2. **ccap_config.h**
   - Added documentation for the new Windows-specific option

3. **ccap_imp_windows.cpp**
   - Modified `findDeviceNames()` with conditional compilation
   - When enabled, directly adds device names without instantiating filters
   - When disabled, preserves original verification behavior

4. **docs/CMAKE_OPTIONS.md** (New)
   - Comprehensive documentation of all CMake build options
   - Includes usage examples and platform-specific notes

## How to Use

Enable the option during build configuration:
```bash
cmake -B build -DCCAP_WIN_NO_DEVICE_VERIFY=ON
cmake --build build
```

## Testing

- ✅ Default behavior preserved (CCAP_WIN_NO_DEVICE_VERIFY=OFF)
- ✅ Option can be enabled without affecting other functionality
- ✅ Device enumeration succeeds even with problematic drivers when enabled
- ✅ No impact on non-Windows platforms

## Technical Details

**Why this approach is safe:**
- `enumerateDevices()` already retrieves friendly device names via `IMoniker::BindToStorage()` 
- This call also validates that the moniker is accessible
- Filter instantiation was only used for additional verification, not required for enumeration

**Comparison with PR #27:**
- PR #27 attempted SEH protection, but exceptions in external DLLs cannot be reliably caught
- This PR completely avoids the problematic code path when enabled
- More robust for exotic/buggy driver scenarios

## Files Changed

- `CMakeLists.txt`: CMake configuration
- `include/ccap_config.h`: Configuration documentation
- `src/ccap_imp_windows.cpp`: Windows implementation
- `docs/CMAKE_OPTIONS.md`: Build documentation (new file)

## Impact

- ✅ Prevents application crashes from buggy drivers on Windows
- ✅ Maintains backward compatibility (disabled by default)
- ✅ Only affects device enumeration, no impact on capture functionality
- ✅ Clear opt-in behavior with compile-time configuration
- ✅ Comprehensive documentation provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows build option to skip device verification, enabling compatibility with buggy camera drivers.

* **Documentation**
  * Added comprehensive documentation covering all CMake build options with usage examples and platform-specific notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->