### PR TITLE
fix(apple): drain capture queue in destroy to avoid UAF on macOS 26

### DIFF
--- a/src/ccap_imp_apple.mm
+++ b/src/ccap_imp_apple.mm
@@ -823,6 +823,18 @@ NSArray<AVCaptureDevice*>* findAllDeviceName() {
 
             [_videoOutput setSampleBufferDelegate:nil queue:dispatch_get_main_queue()];
 
+            // setSampleBufferDelegate:queue: does not guarantee that captureOutput:
+            // blocks already enqueued on the previous capture queue have finished by
+            // the time it returns, especially when the new queue differs from the
+            // old one. Drain the original queue explicitly so ProviderImp (and its
+            // mutexes) cannot be torn down under an in-flight callback. Observed as
+            // crashes inside std::mutex::lock() in getFreeFrame() on macOS 26's
+            // AVCaptureVideoDataOutput_Tundra pipeline.
+            if (_captureQueue) {
+                dispatch_sync(_captureQueue, ^{
+                });
+            }
+
             [_session beginConfiguration];
 
             if (_videoInput) {

--- a/src/ccap_imp_apple.mm
+++ b/src/ccap_imp_apple.mm
@@ -237,6 +237,10 @@ NSArray<AVCaptureDevice*>* findAllDeviceName() {
 
 @end
 
+// Identity key for tagging _captureQueue so destroy can detect re-entrant calls
+// arriving from the capture callback itself (the address is the key, not the value).
+static const void* const kCcapCaptureQueueKey = &kCcapCaptureQueueKey;
+
 @implementation CameraCaptureObjc
 
 - (instancetype)initWithProvider:(ProviderApple*)provider {
@@ -464,6 +468,7 @@ NSArray<AVCaptureDevice*>* findAllDeviceName() {
 
     // Set output queue
     _captureQueue = dispatch_queue_create("ccap.queue", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_set_specific(_captureQueue, kCcapCaptureQueueKey, (__bridge void*)_captureQueue, NULL);
     [_videoOutput setSampleBufferDelegate:self queue:_captureQueue];
 
     // Add output device to session
@@ -830,7 +835,13 @@ NSArray<AVCaptureDevice*>* findAllDeviceName() {
             // mutexes) cannot be torn down under an in-flight callback. Observed as
             // crashes inside std::mutex::lock() in getFreeFrame() on macOS 26's
             // AVCaptureVideoDataOutput_Tundra pipeline.
-            if (_captureQueue) {
+            //
+            // Skip the drain if we're already executing on _captureQueue (e.g. user
+            // code called close() from inside the new-frame callback). dispatch_sync
+            // onto the current serial queue would deadlock, and the drain isn't
+            // needed: the in-flight callback that re-entered us is the only one that
+            // could touch the provider, and it's about to return.
+            if (_captureQueue && dispatch_get_specific(kCcapCaptureQueueKey) != (__bridge void*)_captureQueue) {
                 dispatch_sync(_captureQueue, ^{
                 });
             }


### PR DESCRIPTION
  ### Summary

  On macOS 26 we observed reproducible crashes inside `ccap::ProviderImp::getFreeFrame()` at `std::mutex::lock()`, throwing
  `std::system_error` from an `AVCaptureVideoDataOutput_Tundra` callback on `ccap.queue`:

```
  ccap::ProviderImp::getFreeFrame()
  __56-[AVCaptureVideoDataOutput_Tundra _render:sampleBuffer:]_block_invoke
  _dispatch_lane_serial_drain
```

  ### Root cause

  In `-[CameraCaptureObjc destroy]` we call:

  `[_videoOutput setSampleBufferDelegate:nil queue:dispatch_get_main_queue()];`

  `setSampleBufferDelegate:queue`: does not guarantee that `captureOutput`: blocks already enqueued on the previous capture
  queue have finished by the time it returns, especially when the new queue differs from the old one. On macOS 26's
  reworked capture pipeline, a frame callback can still be in flight on the original `_captureQueue` while we tear down
  `ProviderImp` (and its mutexes), producing a use-after-free that surfaces as a `mutex::lock()` system error.

  ### Fix

  After detaching the delegate, explicitly drain the original capture queue with a `dispatch_sync` barrier before
  destroying session state. This guarantees no `captureOutput`: callback is still running against a soon-to-be-freed
  `ProviderImp`.

```
  if (_captureQueue) {
      dispatch_sync(_captureQueue, ^{ });
  }
```

  ### Impact

  - One-line semantic change, no API change.
  - Fixes a reproducible crash on macOS 26 (also a latent UAF on earlier versions).
  - Negligible cost: a single sync round-trip on a queue we are about to release anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during camera shutdown when capture operations were still in progress.
  * Improved teardown sequencing to ensure in-flight capture callbacks complete without causing races or deadlocks, increasing camera stability during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->